### PR TITLE
fix(state): ensure the correct block number increment for block 0

### DIFF
--- a/src/appchain.cairo
+++ b/src/appchain.cairo
@@ -115,6 +115,9 @@ pub mod appchain {
     /// # Arguments
     ///
     /// * `address` - The contract address of the owner.
+    /// * `state_root` - The state root of the contract.
+    /// * `block_number` - The block number of the contract.
+    /// * `block_hash` - The block hash of the contract.
     #[constructor]
     fn constructor(
         ref self: ContractState,

--- a/src/state/tests/test_state.cairo
+++ b/src/state/tests/test_state.cairo
@@ -50,7 +50,7 @@ fn genesis_state_update_ok() {
         initial_root: 0,
         final_root: 1,
         prev_block_number: 0x800000000000011000000000000000000000000000000000000000000000000,
-        new_block_number: 1,
+        new_block_number: 0,
         prev_block_hash: 0,
         new_block_hash: 1,
         os_program_hash: 1,
@@ -65,7 +65,7 @@ fn genesis_state_update_ok() {
     let (state_root, block_number, block_hash) = mock.get_state();
 
     assert(state_root == 1, 'invalid state root');
-    assert(block_number == 1, 'invalid block number');
+    assert(block_number == 0, 'invalid block number');
     assert(block_hash == 1, 'invalid block hash');
 }
 

--- a/src/state/tests/test_state.cairo
+++ b/src/state/tests/test_state.cairo
@@ -45,11 +45,12 @@ fn state_update_ok() {
 
 #[test]
 fn genesis_state_update_ok() {
-    let mock = deploy_mock_with_state(state_root: 0, block_number: 0, block_hash: 0);
+    let max_felt = 0x800000000000011000000000000000000000000000000000000000000000000;
+    let mock = deploy_mock_with_state(state_root: 0, block_number: max_felt, block_hash: 0);
     let os_output = StarknetOsOutput {
         initial_root: 0,
         final_root: 1,
-        prev_block_number: 0x800000000000011000000000000000000000000000000000000000000000000,
+        prev_block_number: max_felt,
         new_block_number: 0,
         prev_block_hash: 0,
         new_block_hash: 1,
@@ -77,7 +78,7 @@ fn state_update_invalid_block_number() {
     let os_output = StarknetOsOutput {
         initial_root: 1,
         final_root: 2,
-        prev_block_number: 1,
+        prev_block_number: 5,
         new_block_number: 'invalid_block_number',
         prev_block_hash: 1,
         new_block_hash: 2,


### PR DESCRIPTION
When SNOS is executed with the block 0, the `prev_block_number` is equal to `MAX_FELT` as a magic value.

However, the storage of `piltover` is initialized with `block_number` = `0`. To ensure the new state is correctly checked when the `update_state` is called, the increment of the block number is skipped for the block 0, since it's already `0` in the storage.

**EDIT**
Rework the flow to actually rely on the SNOS values instead of incrementing internally in piltover.

The change here is that when piltover is initialized, the `MAX_FELT` value is expected to the `block_number`, since it's the magic value generated by SNOS.