### PR TITLE
feat: add bootloader hash to `ProgramInfo`

### DIFF
--- a/piltover/src/bindgen.rs
+++ b/piltover/src/bindgen.rs
@@ -4965,7 +4965,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> AppchainContract<A> {
     pub fn update_state_getcall(
         &self,
         snos_output: &Vec<starknet::core::types::Felt>,
-        program_output: &Vec<starknet::core::types::Felt>,
+        layout_bridge_output: &Vec<starknet::core::types::Felt>,
         onchain_data_hash: &starknet::core::types::Felt,
         onchain_data_size: &cainome::cairo_serde::U256,
     ) -> starknet::core::types::Call {
@@ -4975,7 +4975,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> AppchainContract<A> {
             snos_output,
         ));
         __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            program_output,
+            layout_bridge_output,
         ));
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(
             onchain_data_hash,
@@ -4994,7 +4994,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> AppchainContract<A> {
     pub fn update_state(
         &self,
         snos_output: &Vec<starknet::core::types::Felt>,
-        program_output: &Vec<starknet::core::types::Felt>,
+        layout_bridge_output: &Vec<starknet::core::types::Felt>,
         onchain_data_hash: &starknet::core::types::Felt,
         onchain_data_size: &cainome::cairo_serde::U256,
     ) -> starknet::accounts::ExecutionV1<A> {
@@ -5004,7 +5004,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> AppchainContract<A> {
             snos_output,
         ));
         __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            program_output,
+            layout_bridge_output,
         ));
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(
             onchain_data_hash,

--- a/piltover/src/bindgen.rs
+++ b/piltover/src/bindgen.rs
@@ -809,9 +809,10 @@ impl OwnershipTransferred {
 }
 #[derive()]
 pub struct ProgramInfo {
-    pub program_hash: starknet::core::types::Felt,
-    pub config_hash: starknet::core::types::Felt,
+    pub bootloader_program_hash: starknet::core::types::Felt,
+    pub snos_config_hash: starknet::core::types::Felt,
     pub snos_program_hash: starknet::core::types::Felt,
+    pub layout_bridge_program_hash: starknet::core::types::Felt,
 }
 impl cainome::cairo_serde::CairoSerde for ProgramInfo {
     type RustType = Self;
@@ -819,21 +820,27 @@ impl cainome::cairo_serde::CairoSerde for ProgramInfo {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.program_hash);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.config_hash);
+        __size +=
+            starknet::core::types::Felt::cairo_serialized_size(&__rust.bootloader_program_hash);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.snos_config_hash);
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.snos_program_hash);
+        __size +=
+            starknet::core::types::Felt::cairo_serialized_size(&__rust.layout_bridge_program_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.program_hash,
+            &__rust.bootloader_program_hash,
         ));
         __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.config_hash,
+            &__rust.snos_config_hash,
         ));
         __out.extend(starknet::core::types::Felt::cairo_serialize(
             &__rust.snos_program_hash,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.layout_bridge_program_hash,
         ));
         __out
     }
@@ -842,16 +849,21 @@ impl cainome::cairo_serde::CairoSerde for ProgramInfo {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let program_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&program_hash);
-        let config_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&config_hash);
+        let bootloader_program_hash =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&bootloader_program_hash);
+        let snos_config_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&snos_config_hash);
         let snos_program_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&snos_program_hash);
+        let layout_bridge_program_hash =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&layout_bridge_program_hash);
         Ok(ProgramInfo {
-            program_hash,
-            config_hash,
+            bootloader_program_hash,
+            snos_config_hash,
             snos_program_hash,
+            layout_bridge_program_hash,
         })
     }
 }

--- a/src/appchain.cairo
+++ b/src/appchain.cairo
@@ -140,7 +140,7 @@ pub mod appchain {
         fn update_state(
             ref self: ContractState,
             snos_output: Span<felt252>,
-            program_output: Span<felt252>,
+            layout_bridge_output: Span<felt252>,
             onchain_data_hash: felt252,
             onchain_data_size: u256,
         ) {
@@ -159,7 +159,7 @@ pub mod appchain {
 
             // Layout bridge program is also bootloaded, and the 3rd element is the hash of the
             // output of the program that has been bootloaded.
-            let layout_bridge_program_hash = program_output.at(2);
+            let layout_bridge_program_hash = layout_bridge_output.at(2);
             assert(
                 program_info.layout_bridge_program_hash == *layout_bridge_program_hash,
                 errors::LAYOUT_BRIDGE_INVALID_PROGRAM_HASH,
@@ -168,13 +168,13 @@ pub mod appchain {
             let snos_output_hash = poseidon_hash_span(snos_output);
             // Layout bridge program is also bootloaded, and the 5th element is the hash of the
             // output of the program that has been layout-bridged.
-            let snos_output_hash_in_bridge_output = program_output.at(4);
+            let snos_output_hash_in_bridge_output = layout_bridge_output.at(4);
             assert(
                 snos_output_hash == *snos_output_hash_in_bridge_output,
                 errors::SNOS_INVALID_OUTPUT_HASH,
             );
 
-            let output_hash = poseidon_hash_span(program_output);
+            let output_hash = poseidon_hash_span(layout_bridge_output);
 
             let mut snos_output_iter = snos_output.into_iter();
             let program_output_struct = deserialize_os_output(ref snos_output_iter);
@@ -183,7 +183,7 @@ pub mod appchain {
                 onchain_data_hash, onchain_data_size,
             };
             let state_transition_fact: u256 = encode_fact_with_onchain_data(
-                program_output, data_availability_fact,
+                layout_bridge_output, data_availability_fact,
             );
 
             assert(

--- a/src/config/interface.cairo
+++ b/src/config/interface.cairo
@@ -9,14 +9,22 @@ use starknet::ContractAddress;
 /// Since the layout used by SNOS is not verifiable onchain, a bridge layout
 /// program is also executed on the proof generated from SNOS execution.
 ///
-/// For this reason, the program info contains the hash of the SNOS program,
-/// additionally to the `program_hash`, which in this case is the bridge layout program hash.
+/// Since the Layout Bridge program is bootloaded, the bootloader program hash
+/// is also included in the program info, as the fact registered in the
+/// facts registry is computed from the Layout Bridge program hash and its output.
+///
 /// This ensures that the correct programs have been executed.
 #[derive(starknet::Store, Drop, Serde, Copy, PartialEq)]
 pub struct ProgramInfo {
-    pub program_hash: felt252,
-    pub config_hash: felt252,
+    /// The hash of the bootloader program that bootloads the Layout Bridge program.
+    pub bootloader_program_hash: felt252,
+    /// The hash of the SNOS config:
+    /// https://github.com/starkware-libs/cairo-lang/blob/a86e92bfde9c171c0856d7b46580c66e004922f3/src/starkware/starknet/core/os/os_config/os_config.cairo#L1-L39
+    pub snos_config_hash: felt252,
+    /// The hash of the SNOS program.
     pub snos_program_hash: felt252,
+    /// The hash of the Layout Bridge program.
+    pub layout_bridge_program_hash: felt252,
 }
 
 #[starknet::interface]

--- a/src/config/tests/test_config.cairo
+++ b/src/config/tests/test_config.cairo
@@ -87,7 +87,12 @@ fn config_set_program_info_ok() {
     snf::start_cheat_caller_address(mock.contract_address, c::OWNER());
 
     // Owner sets the info.
-    let program_info = ProgramInfo { program_hash: 0x1, config_hash: 0x2, snos_program_hash: 0x3 };
+    let program_info = ProgramInfo {
+        bootloader_program_hash: 0x1,
+        snos_config_hash: 0x2,
+        snos_program_hash: 0x3,
+        layout_bridge_program_hash: 0x4,
+    };
     mock.set_program_info(program_info);
     assert(mock.get_program_info() == program_info, 'expect correct hashes');
 
@@ -96,7 +101,10 @@ fn config_set_program_info_ok() {
     // Operator can also set the program info.
     snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR());
     let program_info = ProgramInfo {
-        program_hash: 0x11, config_hash: 0x22, snos_program_hash: 0x33,
+        bootloader_program_hash: 0x11,
+        snos_config_hash: 0x22,
+        snos_program_hash: 0x33,
+        layout_bridge_program_hash: 0x44,
     };
     mock.set_program_info(program_info);
 
@@ -111,7 +119,12 @@ fn config_set_program_info_unauthorized() {
     snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR());
     mock
         .set_program_info(
-            ProgramInfo { program_hash: 0x1, config_hash: 0x2, snos_program_hash: 0x3 },
+            ProgramInfo {
+                bootloader_program_hash: 0x1,
+                snos_config_hash: 0x2,
+                snos_program_hash: 0x3,
+                layout_bridge_program_hash: 0x4,
+            },
         );
 }
 

--- a/src/interface.cairo
+++ b/src/interface.cairo
@@ -17,13 +17,13 @@ pub trait IAppchain<T> {
     /// # Arguments
     ///
     /// * `snos_output` - The StarknetOS state update output (bootloaded).
-    /// * `program_output` - The layout bridge proof output (bootloaded).
+    /// * `layout_bridge_program_output` - The layout bridge proof output (bootloaded).
     /// * `onchain_data_hash` - The hash of the onchain data.
     /// * `onchain_data_size` - The size of the onchain data.
     fn update_state(
         ref self: T,
         snos_output: Span<felt252>,
-        program_output: Span<felt252>,
+        layout_bridge_output: Span<felt252>,
         onchain_data_hash: felt252,
         onchain_data_size: u256,
     );

--- a/src/interface.cairo
+++ b/src/interface.cairo
@@ -16,8 +16,8 @@ pub trait IAppchain<T> {
     ///
     /// # Arguments
     ///
-    /// * `snos_output` - The StarknetOS state update output.
-    /// * `program_output` - The layout bridge proof output.
+    /// * `snos_output` - The StarknetOS state update output (bootloaded).
+    /// * `program_output` - The layout bridge proof output (bootloaded).
     /// * `onchain_data_hash` - The hash of the onchain data.
     /// * `onchain_data_size` - The size of the onchain data.
     fn update_state(


### PR DESCRIPTION
This PR solved two issues:

1. The fact is registered using the program hash of the bootloader, that boatloads the `Layout Bridge` program. Piltover was using the `Layout Bridge` program hash. This PR addresses that by adding the bootloader program hash to the `ProgramInfo`.
2. The `Layout Bridge` program wasn't verified (only `SNOS` was), which could have cause any bootloaded program to be accepted by Piltover. There is now an explicit check of the `Layout Bridge` program hash extracted from the `program_output`.

This PR makes also easier to debug Piltover execution when the fact is not found for the given parameters, which previously panicked with `Index out of bounds`.