### PR TITLE
fix(state): add missing input validation

### DIFF
--- a/tests/test_appchain.cairo
+++ b/tests/test_appchain.cairo
@@ -237,7 +237,7 @@ fn update_state_ok() {
         owner: c::OWNER().into(),
         state_root: 1120029756675208924496185249815549700817638276364867982519015153297469423111,
         block_number: 97999,
-        block_hash: 0,
+        block_hash: 531367489267323329537005801734709408229779133529698992357325410316912085961,
     );
 
     let imsg = IMessagingDispatcher { contract_address: appchain.contract_address };


### PR DESCRIPTION
To be consistent with the [L1 implementation](https://github.com/starkware-libs/cairo-lang/blob/ab8be40403a7634ba296c467b26b8bd945ba5cfa/src/starkware/starknet/solidity/StarknetState.sol#L61) of Starknet, two checks have been added to validate the inputs of the update function:

1. The previous block hash in the SNOS output must match the current block hash of the state
2. The block number must always be greater than the current state (without requirement to be +1)
