### PR TITLE
fix: remove KZG DA support in output deserialization

### DIFF
--- a/src/snos_output.cairo
+++ b/src/snos_output.cairo
@@ -94,14 +94,13 @@ pub fn deserialize_os_output(ref input_iter: SpanIter<felt252>) -> StarknetOsOut
     let header = read_segment(ref input_iter, HEADER_SIZE);
     let use_kzg_da = header[USE_KZG_DA_OFFSET];
     let full_output = header[FULL_OUTPUT_OFFSET];
+
     if use_kzg_da.is_non_zero() {
-        let kzg_segment = read_segment(ref input_iter, 2);
-        let n_blobs: usize = (*kzg_segment.at(KZG_N_BLOBS_OFFSET))
-            .try_into()
-            .expect('Invalid n_blobs');
-        let _ = read_segment(ref input_iter, 2 * 2 * n_blobs);
+        panic!("KZG DA is not supported yet");
     }
+
     let (messages_to_l1, messages_to_l2) = deserialize_messages(ref input_iter);
+
     StarknetOsOutput {
         initial_root: *header[PREVIOUS_MERKLE_UPDATE_OFFSET],
         final_root: *header[NEW_MERKLE_UPDATE_OFFSET],


### PR DESCRIPTION
KZG DA when supported yields a different Starknet OS output, which doesn't contain the state diff. And the KZG proofs are also expected as input. This is currently not supported by piltover.

At the moment, since no work has been done to fully support KZG DA, the support is disabled by panicking if the flag is set to `true` in the Starknet OS output.

When supported, KZG will be implemented in an other entrypoint `update_state_kzg_da` to ensure a better separation of concerns.