### PR TITLE
fix(messaging): ensure message cancellation timer is not reset

### DIFF
--- a/src/messaging/component.cairo
+++ b/src/messaging/component.cairo
@@ -244,14 +244,19 @@ pub mod messaging_cpt {
                 _ => assert(false, errors::NO_MESSAGE_TO_CANCEL),
             };
 
-            self.sn_to_appc_cancellations.write(message_hash, starknet::get_block_timestamp());
+            // If the message has not been cancelled yet, process the cancellation request.
+            // This avoids re-processing the cancellation request if the message is cancelled
+            // multiple times.
+            if self.sn_to_appc_cancellations.read(message_hash).is_zero() {
+                self.sn_to_appc_cancellations.write(message_hash, starknet::get_block_timestamp());
 
-            self
-                .emit(
-                    MessageCancellationStarted {
-                        message_hash, from, to: to_address, selector, payload, nonce,
-                    },
-                );
+                self
+                    .emit(
+                        MessageCancellationStarted {
+                            message_hash, from, to: to_address, selector, payload, nonce,
+                        },
+                    );
+            }
 
             return message_hash;
         }

--- a/src/messaging/component.cairo
+++ b/src/messaging/component.cairo
@@ -244,9 +244,9 @@ pub mod messaging_cpt {
                 _ => assert(false, errors::NO_MESSAGE_TO_CANCEL),
             };
 
-            // If the message has not been cancelled yet, process the cancellation request.
+            // If the cancellation has not been requested yet, process the cancellation request.
             // This avoids re-processing the cancellation request if the message is cancelled
-            // multiple times.
+            // multiple times, which would result in the waiting period to be reset.
             if self.sn_to_appc_cancellations.read(message_hash).is_zero() {
                 self.sn_to_appc_cancellations.write(message_hash, starknet::get_block_timestamp());
 

--- a/src/messaging/tests/test_messaging.cairo
+++ b/src/messaging/tests/test_messaging.cairo
@@ -227,6 +227,10 @@ fn start_cancellation_ok() {
     let message_hash_cancel = mock.start_message_cancellation(to, selector, payload.span(), nonce);
     assert(message_hash == message_hash_cancel, 'invalid message hash');
 
+    // Voluntarily cancel the message again, to ensure the cancellation is not processed twice.
+    let message_hash_cancel = mock.start_message_cancellation(to, selector, payload.span(), nonce);
+    assert(message_hash == message_hash_cancel, 'invalid message hash');
+
     let expected_sent = MessageSent {
         message_hash, from, to, selector, nonce: nonce, payload: payload.span(),
     };
@@ -239,6 +243,8 @@ fn start_cancellation_ok() {
         .assert_emitted(
             @array![
                 (mock.contract_address, Event::MessageSent(expected_sent)),
+                // Only one cancellation event is expected, as the message is already being
+                // cancelled.
                 (mock.contract_address, Event::MessageCancellationStarted(expected_start_cancel)),
             ],
         );

--- a/src/messaging/tests/test_messaging.cairo
+++ b/src/messaging/tests/test_messaging.cairo
@@ -227,7 +227,7 @@ fn start_cancellation_ok() {
     let message_hash_cancel = mock.start_message_cancellation(to, selector, payload.span(), nonce);
     assert(message_hash == message_hash_cancel, 'invalid message hash');
 
-    // Voluntarily cancel the message again, to ensure the cancellation is not processed twice.
+    // Voluntarily start the cancellation again, to ensure the request is not processed twice.
     let message_hash_cancel = mock.start_message_cancellation(to, selector, payload.span(), nonce);
     assert(message_hash == message_hash_cancel, 'invalid message hash');
 
@@ -243,8 +243,8 @@ fn start_cancellation_ok() {
         .assert_emitted(
             @array![
                 (mock.contract_address, Event::MessageSent(expected_sent)),
-                // Only one cancellation event is expected, as the message is already being
-                // cancelled.
+                // Only one cancellation started event is expected, as the message is already in its
+                // cancellation process.
                 (mock.contract_address, Event::MessageCancellationStarted(expected_start_cancel)),
             ],
         );


### PR DESCRIPTION
To cancel a message, a cancellation request must first be sent (`start_message_cancellation`), which uses the block timestamp to then track the necessary delay before `cancel_message` can be called.

This PR ensures that this timer is not reset if the `start_message_cancellation` entrypoint is called multiple times.
