### PR TITLE
operator permissions reduction

### DIFF
--- a/src/config/component.cairo
+++ b/src/config/component.cairo
@@ -74,7 +74,7 @@ pub mod config_cpt {
         }
 
         fn set_program_info(ref self: ComponentState<TContractState>, program_info: ProgramInfo) {
-            self.assert_only_owner_or_operator();
+            get_dep_component!(@self, Ownable).assert_only_owner();
             let old_program_info = self.program_info.read();
             self.program_info.write(program_info);
             self
@@ -92,7 +92,7 @@ pub mod config_cpt {
         }
 
         fn set_facts_registry(ref self: ComponentState<TContractState>, address: ContractAddress) {
-            self.assert_only_owner_or_operator();
+            get_dep_component!(@self, Ownable).assert_only_owner();
             self.facts_registry.write(address)
         }
 
@@ -101,7 +101,7 @@ pub mod config_cpt {
         }
 
         fn set_use_kzg_da(ref self: ComponentState<TContractState>, use_kzg_da: bool) {
-            self.assert_only_owner_or_operator();
+            get_dep_component!(@self, Ownable).assert_only_owner();
             self.use_kzg_da.write(use_kzg_da);
         }
 

--- a/src/config/tests/test_config.cairo
+++ b/src/config/tests/test_config.cairo
@@ -97,14 +97,14 @@ fn config_set_program_info_ok() {
     assert(mock.get_program_info() == program_info, 'expect correct hashes');
 
     // Owner can update the info again.
-    let program_info2 = ProgramInfo {
+    let program_info = ProgramInfo {
         bootloader_program_hash: 0x11,
         snos_config_hash: 0x22,
         snos_program_hash: 0x33,
         layout_bridge_program_hash: 0x44,
     };
-    mock.set_program_info(program_info2);
-    assert(mock.get_program_info() == program_info2, 'expect updated hashes');
+    mock.set_program_info(program_info);
+    assert(mock.get_program_info() == program_info, 'expect updated hashes');
 }
 
 #[test]

--- a/src/config/tests/test_config.cairo
+++ b/src/config/tests/test_config.cairo
@@ -96,26 +96,43 @@ fn config_set_program_info_ok() {
     mock.set_program_info(program_info);
     assert(mock.get_program_info() == program_info, 'expect correct hashes');
 
-    mock.register_operator(c::OPERATOR);
-
-    // Operator can also set the program info.
-    snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
-    let program_info = ProgramInfo {
+    // Owner can update the info again.
+    let program_info2 = ProgramInfo {
         bootloader_program_hash: 0x11,
         snos_config_hash: 0x22,
         snos_program_hash: 0x33,
         layout_bridge_program_hash: 0x44,
     };
-    mock.set_program_info(program_info);
-
-    assert(mock.get_program_info() == program_info, 'expect operator hashes');
+    mock.set_program_info(program_info2);
+    assert(mock.get_program_info() == program_info2, 'expect updated hashes');
 }
 
 #[test]
-#[should_panic(expected: ('Config: not owner or operator',))]
+#[should_panic(expected: ('Caller is not the owner',))]
 fn config_set_program_info_unauthorized() {
     let mock = deploy_mock();
 
+    snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
+    mock
+        .set_program_info(
+            ProgramInfo {
+                bootloader_program_hash: 0x1,
+                snos_config_hash: 0x2,
+                snos_program_hash: 0x3,
+                layout_bridge_program_hash: 0x4,
+            },
+        );
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn config_set_program_info_operator_unauthorized() {
+    let mock = deploy_mock();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+    mock.register_operator(c::OPERATOR);
+
+    // Even a registered operator cannot set program info.
     snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
     mock
         .set_program_info(
@@ -140,17 +157,13 @@ fn config_set_facts_registry_ok() {
     mock.set_facts_registry(facts_registry_address);
     assert(mock.get_facts_registry() == facts_registry_address, 'expect valid address');
 
-    mock.register_operator(c::OPERATOR);
-
-    // Operator can also set the program info.
-    snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
+    // Owner can update the address again.
     mock.set_facts_registry(c::OTHER);
-
     assert(mock.get_facts_registry() == c::OTHER, 'expect other address');
 }
 
 #[test]
-#[should_panic(expected: ('Config: not owner or operator',))]
+#[should_panic(expected: ('Caller is not the owner',))]
 fn config_set_facts_registry_unauthorized() {
     let mock = deploy_mock();
 
@@ -159,4 +172,56 @@ fn config_set_facts_registry_unauthorized() {
     // Other is not an operator.
     snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
     mock.set_facts_registry(facts_registry_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn config_set_facts_registry_operator_unauthorized() {
+    let mock = deploy_mock();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+    mock.register_operator(c::OPERATOR);
+
+    // Even a registered operator cannot set facts registry.
+    snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
+    let facts_registry_address = '0x123'.try_into().unwrap();
+    mock.set_facts_registry(facts_registry_address);
+}
+
+#[test]
+fn config_set_use_kzg_da_ok() {
+    let mock = deploy_mock();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+
+    // Owner enables kzg da.
+    mock.set_use_kzg_da(true);
+    assert(mock.get_use_kzg_da(), 'expect kzg da enabled');
+
+    // Owner disables kzg da.
+    mock.set_use_kzg_da(false);
+    assert(!mock.get_use_kzg_da(), 'expect kzg da disabled');
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn config_set_use_kzg_da_unauthorized() {
+    let mock = deploy_mock();
+
+    // Non-owner cannot set use_kzg_da.
+    snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
+    mock.set_use_kzg_da(true);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner',))]
+fn config_set_use_kzg_da_operator_unauthorized() {
+    let mock = deploy_mock();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+    mock.register_operator(c::OPERATOR);
+
+    // Even a registered operator cannot set use_kzg_da.
+    snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
+    mock.set_use_kzg_da(true);
 }

--- a/tests/test_appchain.cairo
+++ b/tests/test_appchain.cairo
@@ -187,7 +187,7 @@ fn appchain_owner_ok() {
 }
 
 #[test]
-#[should_panic(expected: ('Config: not owner or operator',))]
+#[should_panic(expected: ('Caller is not the owner',))]
 fn appchain_owner_only() {
     let (appchain, _spy) = deploy_with_owner(c::OWNER);
 


### PR DESCRIPTION


<!-- PR description below -->
- Restrict set_program_info, set_facts_registry, and set_use_kzg_da to owner-only access (previously callable 
  by operators too)                                                                                             
- The operator is a hot wallet and should only be allowed to update states — config changes must go through   
  the multisig cold wallet owner                                                                                
                                                                                                              
  Test plan                                                                                                     
                                                                                                              
- Updated existing tests to reflect new owner-only access control                                             
- Added tests verifying registered operators are rejected from set_program_info, set_facts_registry, and
set_use_kzg_da                                                                                                